### PR TITLE
Update dependency on league/oauth2-client@1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ php:
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry phpenv rehash
+
+script:
+  - ./vendor/bin/phpcs --standard=psr2 src/
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+All Notable changes to `oauth2-dropbox` will be documented in this file
+
+## 0.2.0 - 2015-08-20
+
+### Added
+- Upgrade to support version 1.0 release of core client
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
+## 0.1.1 - 2015-02-12
+
+### Added
+- Uses appropriate OAuth2-Client dependency version
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Nothing
+
+### Security
+- Nothing
+
+## 0.1.0 - 2015-02-12
+
+### Added
+- Nothing
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Nothing
+
+### Security
+- Nothing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Contributions are **welcome** and will be fully **credited**.
+
+We accept contributions via Pull Requests on [Github](https://github.com/stevenmaguire/oauth2-dropbox).
+
+
+## Pull Requests
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the README and any other relevant documentation are kept up-to-date.
+
+- **Consider our release cycle** - We try to follow SemVer. Randomly breaking public APIs is not an option.
+
+- **Create topic branches** - Don't ask us to pull from your master branch.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
+
+- **Ensure tests pass!** - Please run the tests (see below) before submitting your pull request, and make sure they pass. We won't accept a patch until all tests pass.
+
+- **Ensure no coding standards violations** - Please run PHP Code Sniffer using the PSR-2 standard (see below) before submitting your pull request. A violation will cause the build to fail, so please make sure there are no violations. We can't accept a patch if the build fails.
+
+
+## Running Tests
+
+``` bash
+$ ./vendor/bin/phpunit
+```
+
+
+## Running PHP Code Sniffer
+
+``` bash
+$ ./vendor/bin/phpcs src --standard=psr2 -sp
+```
+
+**Happy coding**!

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
             "name": "Jason Varga",
             "email": "jason@pixelfear.com",
             "homepage": "https://github.com/pixelfear"
+        },
+        {
+            "name": "Steven Maguire",
+            "email": "stevenmaguire@gmail.com",
+            "homepage": "https://github.com/stevenmaguire"
         }
     ],
     "keywords": [
@@ -19,11 +24,12 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "league/oauth2-client": "1.0.0-beta2"
+        "league/oauth2-client": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "mockery/mockery": "~0.9"
+        "mockery/mockery": "~0.9",
+        "squizlabs/php_codesniffer": "~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Provider/Dropbox.php
+++ b/src/Provider/Dropbox.php
@@ -65,6 +65,7 @@ class Dropbox extends AbstractProvider
     /**
      * Check a provider response for errors.
      *
+     * @link   https://www.dropbox.com/developers/core/docs
      * @throws IdentityProviderException
      * @param  ResponseInterface $response
      * @param  string $data Parsed response data
@@ -72,7 +73,13 @@ class Dropbox extends AbstractProvider
      */
     protected function checkResponse(ResponseInterface $response, $data)
     {
-        // implement me!
+        if (isset($data['error'])) {
+            throw new IdentityProviderException(
+                $data['error'] ?: $response->getReasonPhrase(),
+                $response->getStatusCode(),
+                $response
+            );
+        }
     }
 
     /**

--- a/tests/src/Provider/DropboxTest.php
+++ b/tests/src/Provider/DropboxTest.php
@@ -112,4 +112,24 @@ class DropboxTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($name, $user->getName());
         $this->assertEquals($name, $user->toArray()['display_name']);
     }
+
+    /**
+     * @expectedException League\OAuth2\Client\Provider\Exception\IdentityProviderException
+     **/
+    public function testExceptionThrownWhenErrorObjectReceived()
+    {
+        $message = uniqid();
+        $status = rand(400,600);
+        $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $postResponse->shouldReceive('getBody')->andReturn('{"error": "'.$message.'"}');
+        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $postResponse->shouldReceive('getStatusCode')->andReturn($status);
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')
+            ->times(1)
+            ->andReturn($postResponse);
+        $this->provider->setHttpClient($client);
+        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
 }


### PR DESCRIPTION
This PR updates the package to depend on the newly released v1.0 of the core client. It also includes:

- A new contributing guidelines document
- A new changelog document
- Implementation of `checkResponse` method, with supporting test
- Updated Travis config to run the tests and check the code against the linter