### PR TITLE
Remove un-needed access_token in Resource Owner Details URL

### DIFF
--- a/src/Provider/Dropbox.php
+++ b/src/Provider/Dropbox.php
@@ -94,12 +94,16 @@ class Dropbox extends AbstractProvider
         return new DropboxResourceOwner($response);
     }
 
-    /* Not sure we need this any longer
-    public function getAuthorizationUrl($options = array())
+    /**
+     * Builds the authorization URL.
+     *
+     * @param  array $options
+     * @return string Authorization URL
+     */
+    public function getAuthorizationUrl(array $options = [])
     {
         return parent::getAuthorizationUrl(array_merge([
             'approval_prompt' => []
         ], $options));
     }
-    */
 }

--- a/src/Provider/Dropbox.php
+++ b/src/Provider/Dropbox.php
@@ -46,7 +46,7 @@ class Dropbox extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return 'https://api.dropbox.com/1/account/info?access_token='.$token;
+        return 'https://api.dropbox.com/1/account/info';
     }
 
     /**


### PR DESCRIPTION
Was getting the following error with it in, not sure if this was a Dropbox API change or the way The League OAuth client handles requests.

Cannot specify both an "Authorization" header and the URL/POST parameter "access_token".

Closes #6